### PR TITLE
BWS-67: + validation on create group api

### DIFF
--- a/backend/src/api/eam/eam.api.ts
+++ b/backend/src/api/eam/eam.api.ts
@@ -11,6 +11,8 @@ import {
   EAMGroupGetByTenantRequestParamsDto,
   EAMWorkerCreateRequestDto,
 } from '~/common/types/types';
+import { eamGroupCreate as groupCreateValidationSchema } from '~/validation-schemas/validation-schemas';
+import { FastifyRouteSchemaDef } from 'fastify/types/schema';
 
 type Options = {
   services: {
@@ -48,6 +50,18 @@ const initEamApi: FastifyPluginAsync<Options> = async (fastify, opts) => {
   fastify.route({
     method: HttpMethod.POST,
     url: EAMApiPath.GROUPS,
+    schema: {
+      body: groupCreateValidationSchema,
+    },
+    validatorCompiler({
+      schema,
+    }: FastifyRouteSchemaDef<typeof groupCreateValidationSchema>) {
+      return (
+        data: EAMGroupCreateRequestDto,
+      ): ReturnType<typeof groupCreateValidationSchema['validate']> => {
+        return schema.validate(data);
+      };
+    },
     async handler(
       req: FastifyRequest<{ Body: EAMGroupCreateRequestDto }>,
       rep,

--- a/backend/src/validation-schemas/eam-group/eam-group.ts
+++ b/backend/src/validation-schemas/eam-group/eam-group.ts
@@ -1,0 +1,1 @@
+export { eamGroupCreate } from 'bws-shared/validation/eam-group/eam-group';

--- a/backend/src/validation-schemas/validation-schemas.ts
+++ b/backend/src/validation-schemas/validation-schemas.ts
@@ -1,1 +1,2 @@
 export { eamMasterSignUp, eamMasterSignIn } from './eam-master/eam-master';
+export { eamGroupCreate } from './eam-group/eam-group';

--- a/shared/src/common/enums/enums.ts
+++ b/shared/src/common/enums/enums.ts
@@ -13,5 +13,7 @@ export {
   EAMWorkerValidationRule,
   EAMMasterValidationMessage,
   EAMMasterValidationRule,
+  EAMGroupValidationRule,
+  EAMGroupValidationMessage,
 } from './validation/validation';
 export { Permission } from './permissions/permissions';

--- a/shared/src/common/enums/validation/eam-group/eam-group-validation-massage.ts
+++ b/shared/src/common/enums/validation/eam-group/eam-group-validation-massage.ts
@@ -1,0 +1,11 @@
+import { EAMGroupValidationRule } from './eam-group-validation-rule.enum';
+
+const EAMGroupValidationMessage = {
+  NAME_REQUIRE: 'User cannot create a new group without any name',
+  NAME_MIN_LENGTH: `Group name must have at least ${EAMGroupValidationRule.NAME_MIN_LENGTH} characters`,
+  NAME_MAX_LENGTH: `Group name must be less than  ${EAMGroupValidationRule.NAME_MAX_LENGTH} characters`,
+  NAME_REGEX:
+    'Group name must start and end with a letter (symbols "_", "." are not allowed)',
+} as const;
+
+export { EAMGroupValidationMessage };

--- a/shared/src/common/enums/validation/eam-group/eam-group-validation-rule.enum.ts
+++ b/shared/src/common/enums/validation/eam-group/eam-group-validation-rule.enum.ts
@@ -1,0 +1,7 @@
+const EAMGroupValidationRule = {
+  NAME_MIN_LENGTH: 3,
+  NAME_MAX_LENGTH: 20,
+  NAME_REGEX: /^[a-zA-Z\d][a-zA-Z\d_.]+[a-zA-Z\d]$/,
+} as const;
+
+export { EAMGroupValidationRule };

--- a/shared/src/common/enums/validation/eam-group/eam-group.ts
+++ b/shared/src/common/enums/validation/eam-group/eam-group.ts
@@ -1,0 +1,2 @@
+export { EAMGroupValidationMessage } from './eam-group-validation-massage';
+export { EAMGroupValidationRule } from './eam-group-validation-rule.enum';

--- a/shared/src/common/enums/validation/validation.ts
+++ b/shared/src/common/enums/validation/validation.ts
@@ -7,3 +7,8 @@ export {
   EAMMasterValidationMessage,
   EAMMasterValidationRule,
 } from './eam-master/eam-master';
+
+export {
+  EAMGroupValidationRule,
+  EAMGroupValidationMessage,
+} from './eam-group/eam-group';

--- a/shared/src/common/enums/validation/worker/worker-validation-message.ts
+++ b/shared/src/common/enums/validation/worker/worker-validation-message.ts
@@ -2,7 +2,7 @@ import { EAMWorkerValidationRule } from './create-worker-validation-rule.enum';
 const EAMWorkerValidationMessage = {
   NAME_REQUIRE: 'User cannot create a new user without any name',
   NAME_MIN_LENGTH: `Name must have at least ${EAMWorkerValidationRule.NAME_MIN_LENGTH} characters`,
-  NAME_MAX_LEGTH: `Name must be less than  ${EAMWorkerValidationRule.NAME_MAX_LENGTH} characters`,
+  NAME_MAX_LENGTH: `Name must be less than  ${EAMWorkerValidationRule.NAME_MAX_LENGTH} characters`,
   NAME_REGEX:
     'Name must start and end with a letter (allowed symbols "_", ".")',
 } as const;

--- a/shared/src/validation/eam-group/eam-group-create/group-create.validation-schema.ts
+++ b/shared/src/validation/eam-group/eam-group-create/group-create.validation-schema.ts
@@ -1,0 +1,26 @@
+import * as Joi from 'joi';
+import { getNameOf } from '~/helpers/helpers';
+import { EAMGroupCreateRequestDto } from '~/common/types/types';
+import {
+  EAMGroupValidationMessage,
+  EAMGroupValidationRule,
+} from '~/common/enums/enums';
+
+const eamGroupCreate = Joi.object({
+  [getNameOf<EAMGroupCreateRequestDto>('name')]: Joi.string()
+    .trim()
+    .min(EAMGroupValidationRule.NAME_MIN_LENGTH)
+    .max(EAMGroupValidationRule.NAME_MAX_LENGTH)
+    .regex(EAMGroupValidationRule.NAME_REGEX)
+    .required()
+    .messages({
+      'string.empty': EAMGroupValidationMessage.NAME_REQUIRE,
+      'string.min': EAMGroupValidationMessage.NAME_MIN_LENGTH,
+      'string.pattern.base': EAMGroupValidationMessage.NAME_REGEX,
+    }),
+  [getNameOf<EAMGroupCreateRequestDto>('tenantId')]: Joi.string()
+    .trim()
+    .required(),
+});
+
+export { eamGroupCreate };

--- a/shared/src/validation/eam-group/eam-group.ts
+++ b/shared/src/validation/eam-group/eam-group.ts
@@ -1,0 +1,1 @@
+export { eamGroupCreate } from './eam-group-create/group-create.validation-schema';

--- a/shared/src/validation/validation-schemas.ts
+++ b/shared/src/validation/validation-schemas.ts
@@ -1,2 +1,3 @@
 export { EamWorkerCreate } from './eam-worker/worker';
 export { eamMasterSignUp, eamMasterSignIn } from './eam-master/eam-master';
+export { eamGroupCreate } from './eam-group/eam-group';


### PR DESCRIPTION
While we are getting tenantId in the request body, to avoid an error that tenantId is not allowed, the tenantId is marked as required at validation schema, it must be deleted when simple tenantId transferring logic will be replaced by the token in JWT.