### PR TITLE
BWS-225: + the-placeholder-is-shown-under-the-loader-in-the-empty-table

### DIFF
--- a/frontend/src/components/common/table/table.tsx
+++ b/frontend/src/components/common/table/table.tsx
@@ -122,7 +122,7 @@ const Table: FC<Props> = ({
             </tbody>
           </table>
         )}
-        {hasPlaceholder && (
+        {hasPlaceholder && !isLoading && (
           <div className={styles.placeholder}>{placeholder}</div>
         )}
       </div>


### PR DESCRIPTION
![Screenshot_1](https://user-images.githubusercontent.com/65825815/161032445-97899539-2d2c-4560-ba26-7b6f850029da.png)
